### PR TITLE
Fingerprinting

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,13 @@ This repository contains the source code of Duplicator. While Duplicator itself 
 
 ### Configuration
 
-If you publish the configuration file during installation, the config file should be present at `config/duplicator.php`.
+If you optionally publish the configuration file during installation, it should be present at `config/duplicator.php`. If not, you may publish the config file with the following command:
+
+```
+php artisan vendor:publish --tag="duplicator-config"
+```
+
+The config file looks like this:
 
 ```php
 <?php
@@ -36,10 +42,25 @@ return [
         'published' => true,
     ],
 
+    /*
+    |--------------------------------------------------------------------------
+    | Fingerprint
+    |--------------------------------------------------------------------------
+    |
+    | Should Duplicator leave a 'fingerprint' on each entry/term/asset it touches
+    | so you can tell if it's a duplicated entry or not?
+    |
+    */
+
+    'fingerprint' => false,
+
 ];
 ```
 
-Currently, the configuration file allows you to configure defaults for duplicated entries. For example, if duplicated entries should be published or not. If not configured, it will fallback to the status of the entry being duplicated.
+**Configuration options**
+
+* `defaults` - You can configure defaults for duplicated entries. For example, if duplicated entries should be published or not. If not configured, it will fallback to the status of the entry being duplicated.
+* `fingerprint` - Disabled by default. You can choose whether you'd like a 'fingerprint', in the way of an extra `is_duplicate` variable, to be added to entries/terms/assets duplicated by this addon.
 
 ### Usage
 

--- a/config/duplicator.php
+++ b/config/duplicator.php
@@ -15,4 +15,16 @@ return [
         'published' => true,
     ],
 
+    /*
+    |--------------------------------------------------------------------------
+    | Fingerprint
+    |--------------------------------------------------------------------------
+    |
+    | Should Duplicator leave a 'fingerprint' on each entry/term/asset it touches
+    | so you can tell if it's a duplicated entry or not?
+    |
+    */
+
+    'fingerprint' => false,
+
 ];

--- a/src/Actions/DuplicateAssetAction.php
+++ b/src/Actions/DuplicateAssetAction.php
@@ -31,10 +31,16 @@ class DuplicateAssetAction extends Action
                 if ($item instanceof Asset) {
                     $duplicatePath = str_replace($item->filename(), "{$item->filename()}-02", $item->path());
 
+                    $assetMeta = $item->meta();
+
+                    if (config('duplicator.fingerprint') === true) {
+                        $assetMeta['is_duplicate'] = true;
+                    }
+
                     $asset = AssetAPI::make()
                         ->container($item->container()->handle())
                         ->path($duplicatePath)
-                        ->writeMeta($item->meta());
+                        ->writeMeta($assetMeta);
 
                     Storage::disk($item->container()->diskHandle())->copy($item->path(), $duplicatePath);
                 }

--- a/src/Actions/DuplicateEntryAction.php
+++ b/src/Actions/DuplicateEntryAction.php
@@ -64,6 +64,10 @@ class DuplicateEntryAction extends Action
                             'title' => $itemTitleAndSlug['title'],
                         ]));
 
+                    if (config('duplicator.fingerprint') === true) {
+                        $entry->set('is_duplicate', true);
+                    }
+
                     $entry->save();
 
                     if ($itemParent && $itemParent !== $item->id()) {

--- a/src/Actions/DuplicateTermAction.php
+++ b/src/Actions/DuplicateTermAction.php
@@ -39,6 +39,10 @@ class DuplicateTermAction extends Action
                             'title' => $itemTitleAndSlug['title'],
                         ]));
 
+                    if (config('duplicator.fingerprint') === true) {
+                        $term->set('is_duplicate', true);
+                    }
+
                     $term->save();
                 }
             });

--- a/tests/Actions/DuplicateEntryActionTest.php
+++ b/tests/Actions/DuplicateEntryActionTest.php
@@ -6,8 +6,6 @@ use DoubleThreeDigital\Duplicator\Actions\DuplicateEntryAction;
 use DoubleThreeDigital\Duplicator\Tests\TestCase;
 use Illuminate\Support\Facades\Config;
 use Statamic\Facades\Entry;
-use Statamic\Facades\Site;
-use Statamic\Sites\Sites;
 use Statamic\Structures\CollectionStructure;
 
 class DuplicateEntryActionTest extends TestCase
@@ -155,5 +153,41 @@ class DuplicateEntryActionTest extends TestCase
     public function can_duplicate_entry_for_different_site()
     {
         $this->markTestIncomplete();
+    }
+
+    /** @test */
+    public function can_duplicate_entry_with_fingerprinting_enabled()
+    {
+        Config::set('duplicator.fingerprint', true);
+
+        $collection = $this->makeCollection('guides', 'Guides');
+        $entry = $this->makeEntry('guides', 'new-guide', $this->user);
+
+        $duplicate = $this->action->run(collect([$entry]), []);
+
+        $duplicateEntry = Entry::findBySlug('new-guide-1', 'guides');
+
+        $this->assertIsObject($duplicateEntry);
+        $this->assertSame($duplicateEntry->slug(), 'new-guide-1');
+
+        $this->assertTrue($duplicateEntry->get('is_duplicate'));
+    }
+
+    /** @test */
+    public function can_duplicate_entry_with_fingerprinting_disabled()
+    {
+        Config::set('duplicator.fingerprint', false);
+
+        $collection = $this->makeCollection('guides', 'Guides');
+        $entry = $this->makeEntry('guides', 'news-guide', $this->user);
+
+        $duplicate = $this->action->run(collect([$entry]), []);
+
+        $duplicateEntry = Entry::findBySlug('news-guide-1', 'guides');
+
+        $this->assertIsObject($duplicateEntry);
+        $this->assertSame($duplicateEntry->slug(), 'news-guide-1');
+
+        $this->assertNull($duplicateEntry->get('is_duplicate'));
     }
 }

--- a/tests/Actions/DuplicateTermActionTest.php
+++ b/tests/Actions/DuplicateTermActionTest.php
@@ -1,0 +1,151 @@
+<?php
+
+namespace DoubleThreeDigital\Duplicator\Tests\Actions;
+
+use DoubleThreeDigital\Duplicator\Actions\DuplicateTermAction;
+use DoubleThreeDigital\Duplicator\Tests\TestCase;
+use Illuminate\Support\Facades\Config;
+use Statamic\Facades\Entry;
+use Statamic\Facades\Term;
+use Statamic\Structures\CollectionStructure;
+
+class DuplicateTermActionTest extends TestCase
+{
+    public $user;
+    public $action;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        $this->user = $this->makeStandardUser();
+        $this->action = new DuplicateTermAction();
+    }
+
+    /** @test */
+    public function cant_get_field_items_for_single_site()
+    {
+        $this->markTestIncomplete();
+    }
+
+    /** @test */
+    public function can_get_field_items_for_multi_site()
+    {
+        $this->markTestIncomplete();
+    }
+
+    /** @test */
+    public function is_visible_for_terms()
+    {
+        $taxonomy = $this->makeTaxonomies('categories', 'Categories');
+        $term = $this->makeTerm('categories', 'dance', $this->user);
+
+        $visible = $this->action->visibleTo($term);
+
+        $this->assertTrue($visible);
+    }
+
+    /** @test */
+    public function is_not_visible_for_non_terms()
+    {
+        $taxonomy = $this->makeTaxonomies('categories', 'Categories');
+
+        $visible = $this->action->visibleTo($taxonomy);
+
+        $this->assertFalse($visible);
+    }
+
+    /** @test */
+    public function can_duplicate_term()
+    {
+        $taxonomy = $this->makeTaxonomies('categories', 'Categories');
+        $term = $this->makeTerm('categories', 'haggis', $this->user);
+
+        $duplicate = $this->action->run(collect([$term]), []);
+
+        $duplicateTerm = Term::findBySlug('haggis-1', 'categories');
+
+        $this->assertIsObject($duplicateTerm);
+        $this->assertSame($duplicateTerm->slug(), 'haggis-1');
+    }
+
+    /** @test */
+    public function can_duplicate_entry_with_config_publish_state()
+    {
+        $this->markTestIncomplete();
+
+        Config::set('duplicator.defaults.published', false);
+
+        $taxonomy = $this->makeTaxonomies('categories', 'Categories');
+        $term = $this->makeTerm('categories', 'haggis', $this->user);
+
+        $duplicate = $this->action->run(collect([$term]), []);
+
+        $duplicateTerm = Term::findBySlug('haggis-1', 'categories');
+
+        $this->assertIsObject($duplicateTerm);
+        $this->assertSame($duplicateTerm->slug(), 'haggis-1');
+        $this->assertSame($duplicateTerm->published(), false);
+    }
+
+    /** @test */
+    public function can_duplicate_entry_with_duplicated_entry_publish_state()
+    {
+        $this->markTestIncomplete();
+
+        Config::set('duplicator.defaults.published', null);
+
+        $taxonomy = $this->makeTaxonomies('categories', 'Categories');
+        $term = $this->makeTerm('categories', 'haggis', $this->user);
+
+        $duplicate = $this->action->run(collect([$term]), []);
+
+        $duplicateTerm = Term::findBySlug('haggis-1', 'categories');
+
+        $this->assertIsObject($duplicateTerm);
+        $this->assertSame($duplicateTerm->slug(), 'haggis-1');
+        $this->assertSame($duplicateTerm->published(), false);
+    }
+
+    /** @test */
+    public function can_duplicate_entry_for_different_site()
+    {
+        $this->markTestIncomplete();
+    }
+
+    /** @test */
+    public function can_duplicate_entry_with_fingerprinting_enabled()
+    {
+        Config::set('duplicator.fingerprint', true);
+
+        $taxonomy = $this->makeTaxonomies('categories', 'Categories');
+        $term = $this->makeTerm('categories', 'spaghetti', $this->user);
+
+        $duplicate = $this->action->run(collect([$term]), []);
+
+        $duplicateTerm = Term::findBySlug('spaghetti-1', 'categories');
+
+        $this->assertIsObject($duplicateTerm);
+        $this->assertSame($duplicateTerm->slug(), 'spaghetti-1');
+
+        $this->assertTrue($duplicateTerm->get('is_duplicate'));
+    }
+
+    /** @test */
+    public function can_duplicate_entry_with_fingerprinting_disabled()
+    {
+        Config::set('duplicator.fingerprint', false);
+
+        $taxonomy = $this->makeTaxonomies('categories', 'Categories');
+        $term = $this->makeTerm('categories', 'cheese', $this->user);
+
+        $duplicate = $this->action->run(collect([$term]), []);
+
+        $duplicateTerm = Term::findBySlug('cheese-1', 'categories');
+
+        $this->assertIsObject($duplicateTerm);
+        $this->assertSame($duplicateTerm->slug(), 'cheese-1');
+
+        $this->assertNull($duplicateTerm->get('is_duplicate'));
+    }
+}

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -12,6 +12,8 @@ use Statamic\Providers\StatamicServiceProvider;
 use Statamic\Statamic;
 use Statamic\Facades\Collection;
 use Statamic\Facades\Entry;
+use Statamic\Facades\Taxonomy;
+use Statamic\Facades\Term;
 use Statamic\Facades\User;
 use Statamic\Stache\Stache;
 
@@ -98,5 +100,27 @@ abstract class TestCase extends OrchestraTestCase
             ->save();
 
         return Entry::findBySlug($slug, $collectionHandle);
+    }
+
+    protected function makeTaxonomies(string $handle, string $name)
+    {
+        Taxonomy::make($handle)
+            ->title($name)
+            ->save();
+
+        return Taxonomy::findByHandle($handle);
+    }
+
+    protected function makeTerm(string $taxonomyHandle, string $slug, AuthUser $user)
+    {
+        Term::make($slug)
+            ->taxonomy($taxonomyHandle)
+            ->data([
+                'title' => 'Blah blah blah',
+                'text' => $this->faker->text,
+            ])
+            ->save();
+
+        return Term::findBySlug($slug, $taxonomyHandle);
     }
 }


### PR DESCRIPTION
## Description

<!-- What does this PR change? Has it added anything? Is there any questions you have? -->

This pull request implements a configurable 'fingerprint' option, which if enabled will save an extra `is_duplicate` variable to duplicated 'things'.

## Related Issues

<!-- 
  Does this PR fix an open issue? 
  Link it with a keyword: https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

Closes #27