### PR TITLE
Adds date to Entry::make()

### DIFF
--- a/src/Actions/DuplicateEntryAction.php
+++ b/src/Actions/DuplicateEntryAction.php
@@ -50,6 +50,7 @@ class DuplicateEntryAction extends Action
     {
         collect($items)
             ->each(function ($item) use ($values) {
+                /** @var \Statamic\Entries\Entry $item */
                 if ($item instanceof AnEntry) {
                     $itemParent = $this->getEntryParentFromStructure($item);
                     $itemTitleAndSlug = $this->generateTitleAndSlug($item);
@@ -64,12 +65,12 @@ class DuplicateEntryAction extends Action
                             'title' => $itemTitleAndSlug['title'],
                         ]));
 
-                    if (config('duplicator.fingerprint') === true) {
-                        $entry->set('is_duplicate', true);
+                    if ($item->hasDate()) {
+                        $entry->date($item->date());
                     }
 
-                    if (!is_int($item->date())) {
-                        $entry->date($item->date());
+                    if (config('duplicator.fingerprint') === true) {
+                        $entry->set('is_duplicate', true);
                     }
 
                     $entry->save();

--- a/src/Actions/DuplicateEntryAction.php
+++ b/src/Actions/DuplicateEntryAction.php
@@ -60,6 +60,7 @@ class DuplicateEntryAction extends Action
                         ->locale(isset($values['site']) ? $values['site'] : $item->locale())
                         ->published(config('duplicator.defaults.published', $item->published()))
                         ->slug($itemTitleAndSlug['slug'])
+                        ->date($item->date())
                         ->data($item->data()->merge([
                             'title' => $itemTitleAndSlug['title'],
                         ]));

--- a/src/Actions/DuplicateEntryAction.php
+++ b/src/Actions/DuplicateEntryAction.php
@@ -60,13 +60,16 @@ class DuplicateEntryAction extends Action
                         ->locale(isset($values['site']) ? $values['site'] : $item->locale())
                         ->published(config('duplicator.defaults.published', $item->published()))
                         ->slug($itemTitleAndSlug['slug'])
-                        ->date($item->date())
                         ->data($item->data()->merge([
                             'title' => $itemTitleAndSlug['title'],
                         ]));
 
                     if (config('duplicator.fingerprint') === true) {
                         $entry->set('is_duplicate', true);
+                    }
+
+                    if (!is_int($item->date())) {
+                        $entry->date($item->date());
                     }
 
                     $entry->save();

--- a/tests/Actions/DuplicateEntryActionTest.php
+++ b/tests/Actions/DuplicateEntryActionTest.php
@@ -2,6 +2,7 @@
 
 namespace DoubleThreeDigital\Duplicator\Tests\Actions;
 
+use Carbon\Carbon;
 use DoubleThreeDigital\Duplicator\Actions\DuplicateEntryAction;
 use DoubleThreeDigital\Duplicator\Tests\TestCase;
 use Illuminate\Support\Facades\Config;
@@ -66,6 +67,25 @@ class DuplicateEntryActionTest extends TestCase
 
         $this->assertIsObject($duplicateEntry);
         $this->assertSame($duplicateEntry->slug(), 'fresh-guide-1');
+    }
+
+    /** @test */
+    public function can_duplicate_entry_with_date()
+    {
+        $collection = $this->makeCollection('guides', 'Guides');
+        $entry = $this->makeEntry('guides', 'fresh-guide-smth', $this->user);
+
+        $entry = $entry->date(Carbon::parse('2021-08-08'));
+        $entry->save();
+
+        $duplicate = $this->action->run(collect([$entry]), []);
+
+        $duplicateEntry = Entry::findBySlug('fresh-guide-smth-1', 'guides');
+
+        $this->assertIsObject($duplicateEntry);
+        $this->assertSame($duplicateEntry->slug(), 'fresh-guide-smth-1');
+
+        $this->assertTrue($duplicateEntry->hasDate());
     }
 
     /** @test */


### PR DESCRIPTION
## Description

This PR fixes an error that occurs when the site is set up to use the [Eloquent driver](https://github.com/statamic/eloquent-driver). Duplicated entries would lack a date, thus causing not only an error on the newly created duplicate entry, but also an inability for Statamic to list collection entries at all.