### PR TITLE
Fixes issue with root and children

### DIFF
--- a/src/Actions/DuplicateEntryAction.php
+++ b/src/Actions/DuplicateEntryAction.php
@@ -92,7 +92,7 @@ class DuplicateEntryAction extends Action
             ->page($entry->id())
             ->parent();
 
-        if (is_null($parentEntry) || $entry->structure()->in($entry->locale())->root() === $parentEntry->id()) {
+        if (is_null($parentEntry) || $entry->structure()->in($entry->locale())->root()['entry'] === $parentEntry->id()) {
             return null;
         }
 


### PR DESCRIPTION
## Description

This PR fixes an issue where attempting to duplicate an entry in a collection that has `root: true` would throw the error "Root page cannot have children"

## Explanation

The Gentlemen changed the CollectionTree in [Navigation Blueprints #3941](https://github.com/statamic/cms/pull/3941/files#diff-530461d0d11ee83e368ef5399dce7a565c3a5c40690b42cddf8ef3e6c45a7f67) to include an id key of `entry`