### PR TITLE
Fix asset duplicating when the Stache watcher is disabled

### DIFF
--- a/src/Actions/DuplicateAssetAction.php
+++ b/src/Actions/DuplicateAssetAction.php
@@ -41,8 +41,10 @@ class DuplicateAssetAction extends Action
 
                     $asset = AssetAPI::make()
                         ->container($item->container()->handle())
-                        ->path($duplicatePath)
-                        ->writeMeta($assetMeta);
+                        ->path($duplicatePath);
+
+                    $asset->save();
+                    $asset->writeMeta($assetMeta);
 
                     Storage::disk($item->container()->diskHandle())->copy($item->path(), $duplicatePath);
                 }


### PR DESCRIPTION
<!--
  Please provide an overview of what you've changed. 
  Maybe include a short demo video to go along with it? (https://www.loom.com/)
-->

This pull request fixes an issue where a Duplicated asset wouldn't show as if it had been duplicated if the Stache watcher was disabled.

Fixes #49
